### PR TITLE
Activate twoears general class, optional merge into single hdf5

### DIFF
--- a/datasets/twoears/labelVec2ScalarsBlob.m
+++ b/datasets/twoears/labelVec2ScalarsBlob.m
@@ -19,5 +19,3 @@ else
     y_scalar = y_scalar-1; % 1-based to zero-based class index
     y_scalar = reshape( y_scalar, 1, 1, 1, n ); % to 4-D Blob
 end
-
-

--- a/datasets/twoears/labelVec2ScalarsBlob.m
+++ b/datasets/twoears/labelVec2ScalarsBlob.m
@@ -1,0 +1,23 @@
+function [y_scalar] = labelVec2ScalarsBlob(y_vec)
+% LABELVEC2SCALAR  reduce 4-D Blob matrix of 1-hot ground truth vector
+%   to Blob with scalar ground truth.
+%
+%   A shape of (K x N) is expected for the ground truth y_vec where N is the number of samples
+%   and K is the number of classes.
+%   Sclarization only applies to 1 one-hot ground vectors
+%
+n = length(y_vec);
+y_scalar = reshape(y_vec, [], n); % remove singleton dimensions
+
+if any(sum(y_scalar, 1) > 1)
+    warning('Cannot scalarize multi-labels. Skipping.')
+    y_scalar = [];
+else
+    [class_ids, sample_idx] = find( y_scalar==1 );
+    y_scalar = zeros( 1, n );
+    y_scalar(:, sample_idx) = class_ids;
+    y_scalar = y_scalar-1; % 1-based to zero-based class index
+    y_scalar = reshape( y_scalar, 1, 1, 1, n ); % to 4-D Blob
+end
+
+

--- a/datasets/twoears/removeClassFromVec.m
+++ b/datasets/twoears/removeClassFromVec.m
@@ -1,0 +1,17 @@
+function [y_vec] = removeClassFromVec(y_vec, class_col)
+% REMOVECLASSFROMVEC  remove a class colum from ground truth vectors
+%
+n = length(y_vec);
+classes_dim = find(and(size(y_vec) > 1, size(y_vec) ~= n));
+% determine where the class dimension in the 4D blob is.
+if classes_dim == 1
+    y_vec(class_col, :, :, :, :, :) = [];
+elseif classes_dim == 2
+    y_vec(:, class_col, :, :, :, :) = [];
+elseif classes_dim == 3
+    y_vec(:, :, class_col, :, :, :) = [];
+else
+    error('Unexpected ground truth array size.');
+end
+
+

--- a/datasets/twoears/twoears2Blob.m
+++ b/datasets/twoears/twoears2Blob.m
@@ -1,4 +1,4 @@
-function [x_feat, feature_type_names, y, y_1hot] = twoears2Blob(x, featureNames, y)
+function [x_feat, feature_type_names, y] = twoears2Blob(x, featureNames, y)
 % twoears2Blob  reshape feature and ground truth vectors into 4-D Blob for caffe
 %   For the feature vector x it expects a shape of (N x D)
 %   where N is the number of samples and D is the total no. of features
@@ -47,13 +47,4 @@ end % format features
 
 % reshape multi-label ground truth vectors to 4-D Blob
 y = reshape( y, 1, [], 1, length( y ) );
-
-% labels in one-hot format for softmax loss
-y_1hot = reshape(y, [], length(y));
-[class_ids, sample_idx] = find(y_1hot==1);
-y_1hot = zeros(1, length(y_1hot));
-y_1hot(:, sample_idx) = class_ids;
-y_1hot = y_1hot-1; % 1-based to zero-based class index
-% to 4-D Blob
-y_1hot = reshape(y_1hot, 1, 1, 1, length(y));
 

--- a/datasets/twoears/twoears2hdf5.m
+++ b/datasets/twoears/twoears2hdf5.m
@@ -6,6 +6,8 @@ function [] = twoears2hdf5(fpath, dir_dst, merge)
 %       rows are examples, labels are features/class columns
 %       label states are -1, 0, 1 for inactive, undefined, active
 %       respectively
+%   The general class is only present in the scalar representation of the
+%   ground truth. It is equivalent to an all-zero ground truth vector.
 % 
 if nargin < 3
     merge = false;
@@ -33,6 +35,9 @@ y2 = y2( o, : );
 
 [x_feat, feature_type_names, y] = twoears2Blob(x2, featureNames, y2);
 y_scalar = labelVec2ScalarsBlob(y);
+% Afer scalarizing the ground truth, we can remove the general class column
+% from the ground truths vectors.
+y = removeClassFromVec(y, general_col);
 
 if merge
     % merge all features and ground truth into same hdf5

--- a/datasets/twoears/twoears2hdf5.m
+++ b/datasets/twoears/twoears2hdf5.m
@@ -1,50 +1,91 @@
-function [] = twoears2hdf5(fpath, dir_dst)
+function [] = twoears2hdf5(fpath, dir_dst, merge)
 % TWOEARS2HDF  load twoears training data and reformat into caffe-friendly HDF5
 %   TWOEARS2HDF(fpath, dir_dst) loads data from .mat file designated by fpath
 %     and writes them to hdf5 files under directory dir_dst
-%   Assume rows are examples, labels are features/class columns
+%   Assumes:
+%       rows are examples, labels are features/class columns
+%       label states are -1, 0, 1 for inactive, undefined, active
+%       respectively
 % 
+if nargin < 3
+    merge = false;
+end
 load(fpath, 'x', 'y', 'featureNames', 'classnames');
 
 dir_src = fileparts(fpath);
 [~, phase] = fileparts(dir_src); % test or train from directory name
-assert( strcmp(phase, 'test') | strcmp(phase, 'train'), 'Unable to determine phase (test vs. train).' );
+assert( strcmp(phase, 'test') | strcmp(phase, 'train'), ...
+    'Unable to determine phase (test vs. train).' );
 
-% remove rows with zero entries in ground truth
+% remove rows with zero entries (undefined state) in ground truth
 [nozero, ~] = find( all( y~=0, 2 ) );
 x2 = x( nozero, : );
 y2 = y( nozero, : );
 y2( y2==-1 ) = 0;
 % activate general class wherever all target classes are absent
 general_col = find( strcmp( classnames, 'general' ) );
-y2( sum(y2, 2)==0, general_col) = 1;
+y2( sum(y2, 2)==0, general_col ) = 1;
 
 % random shuffle
 o = randperm( length( y2 ) );
 x2 = x2( o, : );
 y2 = y2( o, : );
 
-[x_feat, feature_type_names, y, y_1hot] = twoears2Blob(x2, featureNames, y2);
+[x_feat, feature_type_names, y] = twoears2Blob(x2, featureNames, y2);
+y_scalar = labelVec2ScalarsBlob(y);
 
-for ii = 1 : numel(feature_type_names)
-    % save formatted features to file
-    fname = sprintf('feat_%s_%s.h5', feature_type_names{ii}, phase);
-    hdf5write( fullfile(dir_dst, fname), strcat('/', feature_type_names{ii}), x_feat{ii});
-    
-    % write hdf5 list files for features
-    file_id = fopen( fullfile(dir_dst, sprintf('feat_%s_%s.txt', feature_type_names{ii}, phase) ),'w');
-    fprintf(file_id, fullfile(dir_dst, sprintf('feat_%s_%s.h5\n', feature_type_names{ii}, phase) ) );
+if merge
+    % merge all features and ground truth into same hdf5
+    prefix_h5 = 'twoears_data';
+    fname_h5 = sprintf('%s_%s.h5', prefix_h5, phase);
+    for ii = 1 : numel(feature_type_names)
+        % save formatted features to file
+        if ii > 1
+            write_mode = 'append';
+        else
+            write_mode = 'overwrite'; % first entry only
+        end
+        hdf5write( fullfile(dir_dst, fname_h5), ...
+            strcat('/', feature_type_names{ii}), x_feat{ii}, ...
+            'WriteMode', write_mode);
+    end
+    % append ground truth to hdf5
+    hdf5write( fullfile(dir_dst, fname_h5), ...
+        '/label', y, ...
+        'WriteMode', 'append');
+    if ~isempty(y_scalar)
+        hdf5write( fullfile(dir_dst, fname_h5), ...
+            '/label_scalar', y_scalar, ...
+            'WriteMode', 'append');
+    end
+    % write hdf5 list files
+    file_id = fopen( fullfile(dir_dst, sprintf('%s_%s.txt', prefix_h5, phase) ), 'w');
+    fprintf(file_id, fullfile(dir_dst, fname_h5) );
+    fclose(file_id);
+else % everything goes into a separate hdf5
+    for ii = 1 : numel(feature_type_names)
+        % save formatted features to file
+        fname = sprintf('feat_%s_%s.h5', feature_type_names{ii}, phase);
+        hdf5write( fullfile(dir_dst, fname), strcat('/', feature_type_names{ii}), x_feat{ii});
+
+        % write hdf5 list files for features
+        file_id = fopen( fullfile(dir_dst, sprintf('feat_%s_%s.txt', ...
+            feature_type_names{ii}, phase) ), 'w');
+        fprintf(file_id, fullfile(dir_dst, sprintf('feat_%s_%s.h5\n', ...
+            feature_type_names{ii}, phase) ) );
+        fclose(file_id);
+    end
+
+    % save ground truth to hdf5(s)
+    hdf5write( fullfile(dir_dst, sprintf('labels_%s.h5', phase) ), '/label', y );
+    hdf5write( fullfile(dir_dst, sprintf('labels_scalar_%s.h5', phase) ), ...
+        '/label', y_scalar );
+
+    % write ground truth hdf5 list files (.txt)
+    file_id = fopen( fullfile(dir_dst, sprintf('labels_%s.txt', phase) ), 'w');
+    fprintf(file_id, fullfile(dir_dst, sprintf('labels_%s.h5\n', phase) ) );
+    fclose(file_id);
+    file_id = fopen( fullfile(dir_dst, sprintf('labels_scalar_%s.txt', phase) ), 'w');
+    fprintf(file_id, fullfile(dir_dst, sprintf('labels_scalar_%s.h5', phase) ) );
     fclose(file_id);
 end
-
-% save ground truth to file(s)
-hdf5write( fullfile(dir_dst, sprintf('labels_%s.h5', phase) ), '/label', y );
-hdf5write( fullfile(dir_dst, sprintf('labels_1hot_%s.h5', phase) ), '/label', y_1hot );
-
-% write hdf5 list files (.txt)
-file_id = fopen( fullfile(dir_dst, sprintf('labels_%s.txt', phase) ),'w');
-fprintf(file_id, fullfile(dir_dst, sprintf('labels_%s.h5\n', phase) ) );
-fclose(file_id);
-file_id = fopen( fullfile(dir_dst, sprintf('labels_1hot_%s.txt', phase) ),'w');
-fprintf(file_id, fullfile(dir_dst, sprintf('labels_1hot_%s.h5', phase) ) );
-fclose(file_id);


### PR DESCRIPTION
If no classes are active, assign the sample to the 'general' class.
However, the vector representation of ground truth is only as long as the number of classes **excluding** the general class.
ground truth vectors that are assigned to the general class are represented by an all-zero vector.